### PR TITLE
automatically handle decompression of gzipped responses

### DIFF
--- a/NGitLab/NGitLab.Tests/NGitLab.Tests.csproj
+++ b/NGitLab/NGitLab.Tests/NGitLab.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NGitLab.Tests</RootNamespace>
     <AssemblyName>NGitLab.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/NGitLab/NGitLab.sln
+++ b/NGitLab/NGitLab.sln
@@ -1,8 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
-MinimumVisualStudioVersion = 10.0.40219.1
+Microsoft Visual Studio Solution File, Format Version 11.00
+# Visual Studio 2010
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NGitLab", "NGitLab\NGitLab.csproj", "{EB69C6AD-64A6-4FE5-880C-38607A2430FB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NGitLab.Tests", "NGitLab.Tests\NGitLab.Tests.csproj", "{B1C9D8F6-22BC-4401-BD7B-E99C62A8E685}"

--- a/NGitLab/NGitLab/Impl/HttpRequestor.cs
+++ b/NGitLab/NGitLab/Impl/HttpRequestor.cs
@@ -191,9 +191,10 @@ namespace NGitLab.Impl
 
         private static WebRequest SetupConnection(Uri url, MethodType methodType)
         {
-            var request = WebRequest.Create(url);
+            var request = (HttpWebRequest)WebRequest.Create(url);
             request.Method = methodType.ToString().ToUpperInvariant();
             request.Headers.Add("Accept-Encoding", "gzip");
+            request.AutomaticDecompression = DecompressionMethods.GZip;
 
             return request;
         }

--- a/NGitLab/NGitLab/Models/ProjectCreate.cs
+++ b/NGitLab/NGitLab/Models/ProjectCreate.cs
@@ -17,7 +17,10 @@ namespace NGitLab.Models
         [DataMember(Name = "description")]
         public string Description;
 
-        [DataMember(Name = "issues_enabled")]
+		[DataMember(Name = "path")]
+		public string Path;
+
+		[DataMember(Name = "issues_enabled")]
         public bool IssuesEnabled;
 
         [DataMember(Name = "wall_enabled")]

--- a/NGitLab/NGitLab/NGitLab.csproj
+++ b/NGitLab/NGitLab/NGitLab.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NGitLab</RootNamespace>
     <AssemblyName>NGitLab</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>


### PR DESCRIPTION
Currently if the server has gzip compression enabled it results in an exception when trying to deserialize the json, we can use the AutomaticDecompression property of HttpWebRequest to automatically handle this for us.